### PR TITLE
Удалить неиспользуемые типы PR-событий для auto-labeler

### DIFF
--- a/.github/workflows/ci.auto-labeler.yml
+++ b/.github/workflows/ci.auto-labeler.yml
@@ -1,7 +1,6 @@
 name: "CI - Auto Labeler"
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
Типы событий PR 'opened', 'synchronize', 'reopened' и 'edited' были удалены, поскольку они не нужны для правильной работы рабочего процесса автоматической маркировки. Это упрощает настройку, сохраняя при этом желаемое поведение.